### PR TITLE
Add the yaml file for PowerShell Updatable Help (CabGen) CI

### DIFF
--- a/cabgen-bootstrap.yml
+++ b/cabgen-bootstrap.yml
@@ -1,0 +1,14 @@
+trigger:
+- live
+
+pr: none # Disable pull request triggers.
+
+resources:
+  repositories:
+    - repository: templates
+      type: git
+      name: Content CI/ReferenceAutomation
+      ref: refs/heads/master
+
+extends:
+  template: PowerShell/cabgen.yml@templates


### PR DESCRIPTION
We recently added _cabgen-bootstrap.yml_ (a pipeline source file) to PowerShell Reference template so that repos on Docs Portal can include it after initialization. This repo is initialized before, so we manually add it now, in case you want to onboard PowerShell Updatable Help (CabGen) CI in the future.
This PR is to _main_ branch, but it should be merged to ***live*** branch before setting up the CI.
For details, see this work item at Azure DevOps: https://dev.azure.com/ceapex/Engineering/_workitems/edit/608278